### PR TITLE
Fixing websocket reconnection, and implementing reconnection backoff

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -12,8 +12,17 @@ export default class Data {
         this.socket.on('gw', (data) => this.parse(data));
     }
 
-    parse(event) {
-        event && event.cmd && this.events[event.cmd] && this.events[event.cmd].filter(([eui, cb]) => event.EUI === eui || eui === false).forEach(([eui, cb]) => cb(event));
+    close() {
+        return this.socket && this.socket.stop();
+    }
+    async parse(event) {
+        return event && event.cmd && this.events[event.cmd] && await Promise.all(
+            this.events[event.cmd]
+                .filter(([eui, cb]) => {
+                    return event.EUI === eui || eui === false;
+                })
+                .map( async ([eui, cb]) => await cb(event))
+            );
     }
 
     all(cb) {

--- a/src/transports/websocket.js
+++ b/src/transports/websocket.js
@@ -6,16 +6,33 @@ export default class WebSocket {
     constructor(settings) {
         this.settings = settings;
         this.socket = null;
+        this.stopped = false;
+        this.startedAt = null;
         this.emitter = new EE3();
         this.callbacks = [];
     }
     
+    stop() {
+        this.stopped = true;
+        this.socket = null;
+    }
     start() {
-        if (!this.socket) this.socket = new InnerWS(`wss://${this.settings.server}.loriot.io/app?id=${this.settings.applicationId}&token=${this.settings.token}`);
+        if (this.stopped) return this;
+        if (this.socket) return this;
+        let currentTime = new Date().getTime();
+        if (this.startedAt && (currentTime - this.startedAt) < 1000) throw Error("Websocket attempted to reconnect twice in < 1s. This is not normal, and may indicates network issues or incorrect credentials.");
+        this.startedAt = currentTime;
+        this.socket = new InnerWS(`wss://${this.settings.server}.loriot.io/app?id=${this.settings.applicationId}&token=${this.settings.token}`);
         this.socket.on('message', (message) => {
             let msg = JSON.parse(message);
             if (msg && msg.cmd) {
                 this.emitter.emit(msg.cmd, msg);
+            }
+        });
+        this.socket.on('close', () => {
+            if (!this.stopped) {
+                this.socket = null;
+                this.start();
             }
         });
         return this;

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -1,18 +1,21 @@
 import assert from 'assert';
 import sinon from 'sinon';
+import util from 'util';
 import ws from 'ws';
 import Data from '../src/data.js';
 
 jest.mock('ws', () => {
     return jest.fn().mockImplementation( function() {
-        
         let callbacks = {
             "message": [],
-            "open": []
+            "open": [],
+            "close": []
         };
 
         this.emit = jest.fn(function(event, data) {
-                callbacks[event].forEach((cb) => cb(data));
+            for (let o of callbacks[event]) {
+                o(data)
+            }
         });
         this.on = jest.fn(function(event, cb) {
                 callbacks[event].push(cb);
@@ -32,7 +35,7 @@ describe('Data', () => {
             token: 'bar'
         });
         
-        let mockedWS = require('ws').mock.instances[0];
+        let mockedWS = data.socket.socket;
         assert.equal(require('ws').mock.calls[0][0], "wss://eu2.loriot.io/app?id=foo&token=bar");
 
         let spy = sinon.spy();
@@ -45,6 +48,7 @@ describe('Data', () => {
             cmd: 'gw',
             EUI: 'test'
         }));
+
         mockedWS.emit('message', JSON.stringify({
             cmd: 'rx',
             EUI: 'foobar',
@@ -68,13 +72,54 @@ describe('Data', () => {
 
         assert(mockedWS.send.mock.calls[0]);
         let output = JSON.parse(mockedWS.send.mock.calls[0][0]);
-        assert.deepEqual(output, {
+        assert.deepStrictEqual(output, {
             cmd: 'tx',
             EUI: 'foobar',
             confirmed: true,
             data: '01',
             port: 1
         });
-
+        data.close();
     });
+    it('Properly resumes connection on data closure', async () => {
+        let data = await Data.fromCredentials({
+            server: 'eu2',
+            applicationId: 'foo',
+            token: 'bar'
+        });
+        
+        let mockedWS = data.socket.socket;
+        let spy = sinon.spy();
+        data.device('foobaz', (message) => {
+            spy(message);
+        });
+        mockedWS.emit('message', JSON.stringify({
+            cmd: 'rx',
+            EUI: 'foobaz',
+            data: '01'
+        }));
+        assert(spy.calledWith({
+            cmd: 'rx',
+            EUI: 'foobaz',
+            data: '01'
+        }));
+        assert(spy.calledOnce);
+        data.socket.startedAt = new Date().getTime() - 1200;
+        mockedWS.emit('close');
+
+        let newMockedWS = data.socket.socket;
+        assert.notStrictEqual(mockedWS, newMockedWS);
+        mockedWS.emit('message', JSON.stringify({
+            cmd: 'rx',
+            EUI: 'foobaz',
+            data: '01'
+        }));
+        assert.strictEqual(spy.callCount, 2);
+
+        assert.throws(() => {
+            mockedWS.emit('close');
+        });
+        data.close();
+
+    })
 })


### PR DESCRIPTION
Two fixes:

- The websocket will now transparently reconnect upon disconnection/upstream closure
- Back-off mechanisms are now in place to handle a disconnection loop (two reconnections in <1s will throw an `Error`)